### PR TITLE
Add connectivity docs

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -9,3 +9,6 @@
 
 - name: Imandra Rule Synth
   baseurl: /imandra-rule-synth
+
+- name: Imandra Connectivity
+  baseurl: /connectivity-docs


### PR DESCRIPTION
Adds `/connectivity-docs` to sidebar in docs pages. Will roll this out by updating the corresponding submodules in each of the docs repos